### PR TITLE
Update build.zig to latest Zig API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -23,7 +23,7 @@ pub fn build(b: *std.Build) void {
         else => {},
     }
 
-    lib.install();
+    _ = b.addInstallArtifact(lib);
 }
 
 const sources = [_][]const u8{


### PR DESCRIPTION
Change lib,install() was deprecated last week. the correct way to install a library is to use `_ = b.addInstallArtifact(lib);` now.