### PR TITLE
Fix `addCSourceFiles` error, and add `build.zig.zon` file with include paths

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,7 +12,7 @@ pub fn build(b: *std.Build) void {
 
     lib.linkLibC();
     lib.addIncludePath(.{ .path = "c/include" });
-    lib.addCSourceFiles(&sources, &.{});
+    lib.addCSourceFiles(.{ .files = &sources });
     lib.installHeadersDirectory("c/include/brotli", "brotli");
 
     const target = cross_target.toTarget();

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = "brotli",
+    .version = "0.0.0",
+    .paths = .{
+        "c/",
+        "LICENSE",
+        "build.zig",
+        "build.zig.zon",
+    },
+}


### PR DESCRIPTION
This fixes an error caused by a change to the `addCSourceFiles` definition.

I'm not sure that the `build.zig.zon` is necessary, but it's been giving me errors in my projects, so I figured I might as well add it. I can remove it if need be.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.