### PR TITLE
Fixing build.zig for 0.12.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) void {
     lib.linkLibC();
     lib.addIncludePath(.{ .path = "c/include" });
     lib.addCSourceFiles(.{ .files = &sources, .flags = &.{} });
-    lib.installHeadersDirectory("c/include/brotli", "brotli");
+    lib.installHeadersDirectory(b.path("c/include/brotli"), "brotli", .{});
 
     switch (target.result.os.tag) {
         .linux => lib.defineCMacro("OS_LINUX", "1"),


### PR DESCRIPTION
# Description

In my own little game project, I've been using `mach-freetype` as a dependency to do text rendering.  I was upgrading my project to use 0.12.0 and I noticed that its dependency `freetype`, and then this transitive dependency needed some small changes to the `build.zig`.

# Issue

With Zig 0.12.0, the current `master` branch fails to build:
```
$ zig version
0.12.0

$ zig build
/home/srjilarious/code/oss/brotli/build.zig:16:8: error: member function expected 3 argument(s), found 2
    lib.installHeadersDirectory("c/include/brotli", "brotli");
    ~~~^~~~~~~~~~~~~~~~~~~~~~~~
/home/srjilarious/.zvm/0.12.0/lib/std/Build/Step/Compile.zig:471:5: note: function declared here
pub fn installHeadersDirectory(
~~~~^~
referenced by:
    runBuild__anon_8992: /home/srjilarious/.zvm/0.12.0/lib/std/Build.zig:2079:27
    main: /home/srjilarious/.zvm/0.12.0/lib/compiler/build_runner.zig:300:29
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```

with this PR, `zig build` now works as expected.

# Changes

The only change is creating a [LazyPath](https://ziglang.org/documentation/master/std/#std.Build.LazyPath) for the source parameter to [installHeadersDirectory](https://ziglang.org/documentation/master/std/#std.Build.Step.Compile.installHeadersDirectory) and adding an empty [HeaderInstallation.Directory.Options](https://ziglang.org/documentation/master/std/#std.Build.Step.Compile.HeaderInstallation.Directory.Options)

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.